### PR TITLE
Upgrade to Slackscot 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.11.3
+      
+    working_directory: /go/src/github.com/alexandre-normand/youppi
+    steps:
+      - checkout
+
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/youppi.go
+++ b/youppi.go
@@ -3,8 +3,8 @@ package main
 import (
 	"github.com/alecthomas/kingpin"
 	"github.com/alexandre-normand/slackscot"
-	"github.com/alexandre-normand/slackscot/brain"
 	"github.com/alexandre-normand/slackscot/config"
+	"github.com/alexandre-normand/slackscot/plugins"
 	"log"
 )
 
@@ -20,9 +20,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	youppi := slackscot.NewSlackscot([]slackscot.ExtentionBundle{brain.NewKarma(), brain.NewImager(), brain.NewFingerQuoter(), brain.NewEmojiBannerMaker()})
+	youppi := slackscot.NewSlackscot("youppi", []slackscot.Plugin{plugins.NewKarma(), plugins.NewImager(), plugins.NewFingerQuoter(), plugins.NewEmojiBannerMaker()})
 
-	err = slackscot.Run(*youppi, *config)
+	err = youppi.Run(*config)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
@s-machina: This depends on https://github.com/alexandre-normand/slackscot/pull/5 (and the `circle ci` build will fail until I merge that one). 

As I start making more changes to [slackscot](https://github.com/alexandre-normand/slackscot), I'll probably look into [go modules](https://golang.org/cmd/go/#hdr-Module_maintenance) and vendoring. 
